### PR TITLE
Disable EnvironmentVariablesTest on JDKs >=17

### DIFF
--- a/src/test/java/com/fortitudetec/junit/pioneering/EnvironmentVariablesTest.java
+++ b/src/test/java/com/fortitudetec/junit/pioneering/EnvironmentVariablesTest.java
@@ -6,12 +6,15 @@ import static org.assertj.core.api.Assertions.assertThat;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledForJreRange;
+import org.junit.jupiter.api.condition.JRE;
 import org.junitpioneer.jupiter.ClearEnvironmentVariable;
 import org.junitpioneer.jupiter.SetEnvironmentVariable;
 
 @DisplayName("Environment Variable Annotations")
 @SetEnvironmentVariable(key = "CLASS_VAR_1", value = "value1")
 @SetEnvironmentVariable(key = "CLASS_VAR_2", value = "value2")
+@DisabledForJreRange(min = JRE.JAVA_17, disabledReason = "illegal reflective access on JDK 17 and higher")
 class EnvironmentVariablesTest {
 
     @BeforeAll


### PR DESCRIPTION
Disable this test on JDK 17 and above. Otherwise, you get
an illegl reflective access error.

See https://junit-pioneer.org/docs/environment-variables/#warnings-for-reflective-access