### PR TITLE
Remove junit-platform-launcher dependency; it is defined in kiwi-parent

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -17,7 +17,6 @@
     <name>JUnit Pioneering Presentation Example Code</name>
 
     <properties>
-        <junit-platform-launcher.version>1.9.1</junit-platform-launcher.version>
         <kiwi.version>2.3.0</kiwi.version>
         <kiwi-test.version>2.3.0</kiwi-test.version>
         <logback-classic.version>1.4.1</logback-classic.version>
@@ -48,13 +47,6 @@
         </dependency>
 
         <!-- test dependencies -->
-
-        <dependency>
-            <groupId>org.junit.platform</groupId>
-            <artifactId>junit-platform-launcher</artifactId>
-            <version>${junit-platform-launcher.version}</version>
-            <scope>test</scope>
-        </dependency>
 
         <dependency>
             <groupId>org.junit-pioneer</groupId>


### PR DESCRIPTION
Since junit-platform-launcher is defined in the parent POM, we should not re-define it here, especially with a different version.

Closes #73