### PR TITLE
Refactor cartesian test example to use CartesianTest

### DIFF
--- a/src/test/java/com/fortitudetec/junit/pioneering/CartesianProductTestAnnotationTest.java
+++ b/src/test/java/com/fortitudetec/junit/pioneering/CartesianProductTestAnnotationTest.java
@@ -5,9 +5,10 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import com.google.common.collect.Range;
 import org.junit.jupiter.api.DisplayName;
-import org.junitpioneer.jupiter.CartesianEnumSource;
-import org.junitpioneer.jupiter.CartesianProductTest;
-import org.junitpioneer.jupiter.CartesianValueSource;
+import org.junitpioneer.jupiter.cartesian.ArgumentSets;
+import org.junitpioneer.jupiter.cartesian.CartesianTest;
+import org.junitpioneer.jupiter.cartesian.CartesianTest.Enum.Mode;
+import org.junitpioneer.jupiter.cartesian.CartesianTest.Values;
 import org.junitpioneer.jupiter.params.IntRangeSource;
 import org.junitpioneer.jupiter.params.LongRangeSource;
 
@@ -18,14 +19,17 @@ import java.util.stream.Stream;
 public class CartesianProductTestAnnotationTest {
 
     // 4 inputs (2 to 2nd power)
-    @CartesianProductTest({"0", "1"})
-    void shouldProduceAllCombinationsOfTwo(String x, String y) {
+    @CartesianTest
+    void shouldProduceAllCombinationsOfTwo(@Values(strings = {"0", "1"}) String x,
+                                           @Values(strings = {"0", "1"}) String y) {
         List.of(x, y).forEach(this::assertIsZeroOrOne);
     }
 
     // 8 inputs (2 to 3rd power)
-    @CartesianProductTest({"0", "1"})
-    void shouldProduceAllCombinationsOfThree(String x, String y, String z) {
+    @CartesianTest
+    void shouldProduceAllCombinationsOfThree(@Values(strings = {"0", "1"}) String x,
+                                             @Values(strings = {"0", "1"}) String y,
+                                             @Values(strings = {"0", "1"}) String z) {
         List.of(x, y, z).forEach(this::assertIsZeroOrOne);
     }
 
@@ -36,14 +40,21 @@ public class CartesianProductTestAnnotationTest {
     }
 
     // 27 inputs (3 to 3rd power)
-    @CartesianProductTest({"A", "B", "C"})
-    void shouldProduceAllCombinationsOfThree_ForThreeInputs(String x, String y, String z) {
+    @CartesianTest
+    void shouldProduceAllCombinationsOfThree_ForThreeInputs(
+            @Values(strings = {"A", "B", "C"}) String x,
+            @Values(strings = {"A", "B", "C"}) String y,
+            @Values(strings = {"A", "B", "C"}) String z) {
         List.of(x, y, z).forEach(this::assertIsABC);
     }
 
     // 81 inputs (3 to fourth power)
-    @CartesianProductTest({"A", "B", "C"})
-    void shouldProduceAllCombinationsOfThree_ForFourInputs(String w, String x, String y, String z) {
+    @CartesianTest
+    void shouldProduceAllCombinationsOfThree_ForFourInputs(
+            @Values(strings = {"A", "B", "C"}) String w,
+            @Values(strings = {"A", "B", "C"}) String x,
+            @Values(strings = {"A", "B", "C"}) String y,
+            @Values(strings = {"A", "B", "C"}) String z) {
         List.of(w, x, y, z).forEach(this::assertIsABC);
     }
 
@@ -57,57 +68,57 @@ public class CartesianProductTestAnnotationTest {
         SUCCEEDED, FAILED, SKIPPED
     }
 
-    @CartesianProductTest
-    @CartesianValueSource(strings = {"A", "B", "C"})
-    @CartesianValueSource(ints = {1, 2, 3})
-    @CartesianEnumSource(value = Result.class,
-            names = {"SKIPPED"},
-            mode = CartesianEnumSource.Mode.EXCLUDE)
-    void shouldProduceAllCombinationsForCartesianValueSources(String x, int y, Result z) {
+    @CartesianTest
+    void shouldProduceAllCombinationsForCartesianValueSources(
+            @Values(strings = {"A", "B", "C"}) String x,
+            @Values(ints = {1, 2, 3}) int y,
+            @CartesianTest.Enum(
+                    value = Result.class, names = {"SKIPPED"}, mode = Mode.EXCLUDE) Result z) {
         assertThat(equalsAny(x, "A", "B", "C")).isTrue();
         assertThat(Range.closed(1, 3).contains(y)).isTrue();
         assertThat(z).isNotNull();
     }
 
-    @CartesianProductTest
-    @IntRangeSource(from = 1, to = 4, closed = true)
-    @LongRangeSource(from = 1000, to = 1005, closed = true)
-    void shouldWorkWithRangeSources(int x, long y) {
+    @CartesianTest
+    void shouldWorkWithRangeSources(@IntRangeSource(from = 1, to = 4, closed = true) int x,
+                                    @LongRangeSource(from = 1000, to = 1005, closed = true) long y) {
         assertThat(Range.closed(1, 4).contains(x)).isTrue();
         assertThat(Range.closed(1000L, 1005L).contains(y)).isTrue();
     }
 
-    @CartesianProductTest
+    @CartesianTest
+    @CartesianTest.MethodFactory("nFold")
     void nFold(String greek, Result result, int level) {
         assertThat(equalsAny(greek, "Alpha", "Beta", "Gamma")).isTrue();
         assertThat(result).isNotNull();
         assertThat(Range.closedOpen(0, 5).contains(level)).isTrue();
     }
 
-    // This *is* used by the above nFold test annotated with @CartesianProductTest
+    // This *is* used by the above nFold test annotated with @CartesianTest.MethodFactory
     // even though IntelliJ thinks it isn't.
     @SuppressWarnings("unused")
-    static CartesianProductTest.Sets nFold() {
-        return new CartesianProductTest.Sets()
-                .add("Alpha", "Beta", "Gamma")
-                .add((Object[]) Result.values())
-                .addAll(Stream.iterate(0, val -> val + 1).limit(5));
+    static ArgumentSets nFold() {
+        return ArgumentSets
+                .argumentsForFirstParameter("Alpha", "Beta", "Gamma")
+                .argumentsForNextParameter((Object[]) Result.values())
+                .argumentsForNextParameter(Stream.iterate(0, val -> val + 1).limit(5));
     }
 
-    @CartesianProductTest(factory = "customProduct")
+    @CartesianTest
+    @CartesianTest.MethodFactory("customProduct")
     void shouldAllowCustomArgumentFactory(String greek, Result result, int level) {
         assertThat(equalsAny(greek, "Alpha", "Beta", "Gamma")).isTrue();
         assertThat(result).isNotNull();
         assertThat(Range.closedOpen(0, 5).contains(level)).isTrue();
     }
 
-    // This *is* used by the above test annotated with @CartesianProductTest specifying this
+    // This *is* used by the above test annotated with @CartesianTest specifying this
     // method as the factory.
     @SuppressWarnings("unused")
-    static CartesianProductTest.Sets customProduct() {
-        return new CartesianProductTest.Sets()
-                .add("Alpha", "Beta", "Gamma")
-                .add((Object[]) Result.values())
-                .addAll(Stream.iterate(0, val -> val + 1).limit(5));
+    static ArgumentSets customProduct() {
+        return ArgumentSets
+                .argumentsForFirstParameter("Alpha", "Beta", "Gamma")
+                .argumentsForNextParameter((Object[]) Result.values())
+                .argumentsForNextParameter(Stream.iterate(0, val -> val + 1).limit(5));
     }
 }


### PR DESCRIPTION
CartesianProductTest is deprecated, so refactor the cartesian example test to use the replacement CartesianTest annotation.

Closes #65