### PR TITLE
Rename cartesian test; remove "Product" from name

### DIFF
--- a/src/test/java/com/fortitudetec/junit/pioneering/CartesianTestAnnotationTest.java
+++ b/src/test/java/com/fortitudetec/junit/pioneering/CartesianTestAnnotationTest.java
@@ -15,8 +15,8 @@ import org.junitpioneer.jupiter.params.LongRangeSource;
 import java.util.List;
 import java.util.stream.Stream;
 
-@DisplayName("@CartesianProductTest")
-public class CartesianProductTestAnnotationTest {
+@DisplayName("@CartesianTest")
+public class CartesianTestAnnotationTest {
 
     // 4 inputs (2 to 2nd power)
     @CartesianTest


### PR DESCRIPTION
The junit-pioneer `@CartesianTest` replaces `@CartesianProductTest`, so rename our test excluding "Product" to `CartesianTestAnnotationTest`

Refs #65