### PR TITLE
Fix DefaultLocale test that fails in JUnit Pioneer 2.x

### DIFF
--- a/src/test/java/com/fortitudetec/junit/pioneering/DefaultLocaleAndTimeZoneTest.java
+++ b/src/test/java/com/fortitudetec/junit/pioneering/DefaultLocaleAndTimeZoneTest.java
@@ -32,7 +32,7 @@ class DefaultLocaleAndTimeZoneTest {
 
     @Test
     void shouldSetDefaultLocaleFromClassLevel() {
-        assertThat(Locale.getDefault()).isEqualTo(new Locale("es"));
+        assertThat(Locale.getDefault()).isEqualTo(new Locale.Builder().setLanguage("es").build());
     }
 
     @Nested
@@ -56,15 +56,16 @@ class DefaultLocaleAndTimeZoneTest {
         @Test
         @DefaultLocale(language = "es", country = "MX")
         void usingLanguageAndCountry() {
-            assertThat(Locale.getDefault()).isEqualTo(new Locale("es", "MX"));
+            assertThat(Locale.getDefault()).isEqualTo(
+                    new Locale.Builder().setLanguage("es").setRegion("MX").build());
         }
 
-        // nan-Hant-TW (Min Nan Chinese as spoken in Taiwan using traditional Han characters)
-        // (source: https://en.wikipedia.org/wiki/IETF_language_tag)
+        // see: https://en.wikipedia.org/wiki/IETF_language_tag
         @Test
-        @DefaultLocale(language = "nan", country = "TW", variant = "Hant")
+        @DefaultLocale(language = "ja", country = "JP", variant = "japanese")
         void usingLanguageAndCountryAndVariant() {
-            assertThat(Locale.getDefault()).isEqualTo(new Locale("nan", "TW", "Hant"));
+            assertThat(Locale.getDefault()).isEqualTo(
+                new Locale.Builder().setLanguage("ja").setRegion("JP").setVariant("japanese").build());
         }
     }
 


### PR DESCRIPTION
Using the "Hant" variant for Min Man Chinese (language: nan) and Taiwan (country: TW) fails in JUnit Pioneer 2.0.0 because of breaking changes.

See the issue here:
https://github.com/junit-pioneer/junit-pioneer/issues/658

Basically, Pioneer changed from using the Locale constructors (which are deprecated as of Java 19) to the Locale Builder, which is more strict and checks the variant. Trying to use "Hant" as the variant throws an IllformedLocaleException. So, used the same language, country, and variant that Pioneer uses in its own tests: ja, JP, and japanese respectively.